### PR TITLE
Reflect name change of function in usage

### DIFF
--- a/NaiveChecker.py
+++ b/NaiveChecker.py
@@ -18,7 +18,7 @@ selected_column_list = SELECTED_COLUMNS_STRING.split(",")
 def whitespace_stripper(string):
     return(string.strip())
 
-selected_column_list = list(map(stripper, selected_column_list))
+selected_column_list = list(map(whitespace_stripper, selected_column_list))
 
 train = pd.read_csv(INPUT_PATH + "/train.tsv", sep="\t")
 dev = pd.read_csv(INPUT_PATH + "/train.tsv", sep="\t")


### PR DESCRIPTION
The whitespace stripper function name was changed in development, but its usage was not changed accordingly. It has been changed in this commit.